### PR TITLE
Fixed Pokeball button image

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -27,7 +27,7 @@
 
 #pokeball {
   background-color: transparent;
-  background-image: url("https://upload.wikimedia.org/wikipedia/en/3/39/Pokeball.PNG");
+  background-image: url("https://upload.wikimedia.org/wikipedia/commons/thumb/5/53/Pok%C3%A9_Ball_icon.svg/1200px-Pok%C3%A9_Ball_icon.svg.png");
   background-size: cover;
   width: 30px;
   height: 30px;

--- a/js/index.js
+++ b/js/index.js
@@ -41,3 +41,6 @@ function getPokeInfo() {
 }
 
 document.getElementById("pokeball").addEventListener("click", getPokeInfo);
+document.getElementById("input").addEventListener("keydown", event => {
+  if (event.isComposing || event.keyCode === 13) getPokeInfo();
+})


### PR DESCRIPTION
It made me super sad when the Pokedex didn't seem to be working.  Apparently the Pokeball image broke at some point.
<img width="887" alt="Screen Shot 2021-04-29 at 2 48 03 PM" src="https://user-images.githubusercontent.com/16297628/116622801-199de280-a8fa-11eb-91f7-0eca0f98f391.png">

I swapped out the image url for a fresh one, and added Enter functionality to the input just in case the button disappears again.

<img width="828" alt="Screen Shot 2021-04-29 at 2 48 21 PM" src="https://user-images.githubusercontent.com/16297628/116622806-1d316980-a8fa-11eb-84c8-53162252e45f.png">
